### PR TITLE
WithdrawNFT can now specify nft IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,13 @@ Likewise, the `holder` account can specify which NFTs will be put for handover.
 
 ```bash
 # With this transaction, we specify the tokens from which NFT smart contract we want to handover.
-flow transactions send ./cadence/transactions/lockUps/lockNonFungibleToken.cdc $DOMAINS_IDENTIFIER --network=emulator --signer=holder
+flow transactions send ./cadence/transactions/lockUps/lockNonFungibleToken.cdc $DOMAINS_IDENTIFIER nil --network=emulator --signer=holder
 
 # Let's view the updated public info of the AssetHandover.LockUp resource.
 flow scripts execute ./cadence/scripts/lockUps/getAccountLockUp.cdc $HOLDER_ADDRESS --network=emulator
 
 # => Output:
-Result: A.01cf0e2f2f715450.AssetHandover.LockUpInfo(holder: 0x179b6b1cb6755e31,  releasedAt: 1700034523, createdAt: 1681678028, name: "first backup", description: "Its going to be used for all of my assets", recipient: 0xf3fcd2c1a78f5eee, fungibleTokens: [A.01cf0e2f2f715450.AssetHandover.FTLockUpInfo(identifier: "A.0ae53cb6e3f42a79.FlowToken", balance: 450.00000000), A.01cf0e2f2f715450.AssetHandover.FTLockUpInfo(identifier: "A.01cf0e2f2f715450.BlpToken", balance: nil)], nonFungibleTokens: [A.01cf0e2f2f715450.AssetHandover.NFTLockUpInfo(identifier: "A.01cf0e2f2f715450.Domains", nftIDs: [])])
+Result: A.01cf0e2f2f715450.AssetHandover.LockUpInfo(holder: 0x179b6b1cb6755e31,  releasedAt: 1700034523, createdAt: 1681678028, name: "first backup", description: "Its going to be used for all of my assets", recipient: 0xf3fcd2c1a78f5eee, fungibleTokens: [A.01cf0e2f2f715450.AssetHandover.FTLockUpInfo(identifier: "A.0ae53cb6e3f42a79.FlowToken", balance: 450.00000000), A.01cf0e2f2f715450.AssetHandover.FTLockUpInfo(identifier: "A.01cf0e2f2f715450.BlpToken", balance: nil)], nonFungibleTokens: [A.01cf0e2f2f715450.AssetHandover.NFTLockUpInfo(identifier: "A.01cf0e2f2f715450.Domains", nftIDs: [0])])
 ```
 
 ### 9. Recipient account withdraws the NFTs from the LockUp
@@ -729,7 +729,7 @@ export EXAMPLE_NFT_IDENTIFIER=A.f8d6e0586b0a20c7.ExampleNFT
 
 ```bash
 # We specify that tokens of the ExampleNFT Collection, will also be handed over.
-flow transactions send ./cadence/transactions/lockUps/lockNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER --network=emulator --signer=holder
+flow transactions send ./cadence/transactions/lockUps/lockNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER nil --network=emulator --signer=holder
 
 # Let's view the updated public info of the AssetHandover.LockUp resource
 flow scripts execute ./cadence/scripts/lockUps/getAccountLockUp.cdc $HOLDER_ADDRESS --network=emulator
@@ -765,6 +765,9 @@ flow scripts execute ./cadence/scripts/exampleNFT/getNFTids.cdc $HOLDER_ADDRESS 
 
 # Output: =>
 Result: [0]
+
+# Let's add the newly minted NFT to the lock-up
+flow transactions send ./cadence/transactions/lockUps/lockNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER '[0]' --network=emulator --signer=holder
 
 # Recipient account can now withdraw ExampleNFT tokens from holder account.
 flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ With the `AssetHandover.LockUp` resource in place, let's see how the `recipient`
 flow transactions send ./cadence/transactions/flow/transferFlowTokens.cdc $RECIPIENT_ADDRESS 1000.0 --network=emulator --signer=emulator-account
 
 # Viewing the AssetHandover.LockUp public info, the recipient can specify which NFTs to withdraw.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient
 
 # => Output: It turns out that the recipient account cannot hold NFTs from the Domains smart contract, without a Domains.Collection resource in the account storage.
 error: panic("You do not own such an NFT Collection.")
@@ -415,7 +415,7 @@ error: panic("You do not own such an NFT Collection.")
 node cadence/transactions/lockUps/initCollection.js $DOMAINS_IDENTIFIER recipient
 
 # Second attempt at withdrawing the Domains NFTs
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient
 
 # => Output: The value of  the `releasedAt` field is a Unix timestamp which points to a future date, hence we cannot withdraw yet.
 error: panic: The assets are still in lock-up period!
@@ -424,7 +424,7 @@ error: panic: The assets are still in lock-up period!
 flow transactions send ./cadence/transactions/lockUps/setLockUpReleasedAt.cdc 1663224523 --network=emulator --signer=holder
 
 # Recipient attempts to withdraw the NFTs again.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient
 
 # We check the Domains.Collection of the recipient, and we see the only NFT that was previously owned by the holder.
 flow scripts execute ./cadence/scripts/domains/getAccountCollection.cdc $RECIPIENT_ADDRESS --network=emulator
@@ -767,7 +767,7 @@ flow scripts execute ./cadence/scripts/exampleNFT/getNFTids.cdc $HOLDER_ADDRESS 
 Result: [0]
 
 # Recipient account can now withdraw ExampleNFT tokens from holder account.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient
 
 # => Output: The recipient account is not set up to receive such NFTs.
 error: panic: You do not own such an NFT Collection.
@@ -776,7 +776,7 @@ error: panic: You do not own such an NFT Collection.
 node cadence/transactions/lockUps/initCollection.js $EXAMPLE_NFT_IDENTIFIER recipient
 
 # Recipient attempts again to withdraw ExampleNFT tokens.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS nil --network=emulator --signer=recipient
 
 # The withdrwawl should have been successful.
 flow scripts execute ./cadence/scripts/exampleNFT/getNFTids.cdc $RECIPIENT_ADDRESS --network=emulator

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ With the `AssetHandover.LockUp` resource in place, let's see how the `recipient`
 flow transactions send ./cadence/transactions/flow/transferFlowTokens.cdc $RECIPIENT_ADDRESS 1000.0 --network=emulator --signer=emulator-account
 
 # Viewing the AssetHandover.LockUp public info, the recipient can specify which NFTs to withdraw.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
 
 # => Output: It turns out that the recipient account cannot hold NFTs from the Domains smart contract, without a Domains.Collection resource in the account storage.
 error: panic("You do not own such an NFT Collection.")
@@ -415,7 +415,7 @@ error: panic("You do not own such an NFT Collection.")
 node cadence/transactions/lockUps/initCollection.js $DOMAINS_IDENTIFIER recipient
 
 # Second attempt at withdrawing the Domains NFTs
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
 
 # => Output: The value of  the `releasedAt` field is a Unix timestamp which points to a future date, hence we cannot withdraw yet.
 error: panic: The assets are still in lock-up period!
@@ -424,7 +424,7 @@ error: panic: The assets are still in lock-up period!
 flow transactions send ./cadence/transactions/lockUps/setLockUpReleasedAt.cdc 1663224523 --network=emulator --signer=holder
 
 # Recipient attempts to withdraw the NFTs again.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $DOMAINS_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
 
 # We check the Domains.Collection of the recipient, and we see the only NFT that was previously owned by the holder.
 flow scripts execute ./cadence/scripts/domains/getAccountCollection.cdc $RECIPIENT_ADDRESS --network=emulator
@@ -767,7 +767,7 @@ flow scripts execute ./cadence/scripts/exampleNFT/getNFTids.cdc $HOLDER_ADDRESS 
 Result: [0]
 
 # Recipient account can now withdraw ExampleNFT tokens from holder account.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
 
 # => Output: The recipient account is not set up to receive such NFTs.
 error: panic: You do not own such an NFT Collection.
@@ -776,7 +776,7 @@ error: panic: You do not own such an NFT Collection.
 node cadence/transactions/lockUps/initCollection.js $EXAMPLE_NFT_IDENTIFIER recipient
 
 # Recipient attempts again to withdraw ExampleNFT tokens.
-flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS --network=emulator --signer=recipient
+flow transactions send ./cadence/transactions/lockUps/withdrawNonFungibleToken.cdc $EXAMPLE_NFT_IDENTIFIER $HOLDER_ADDRESS '[]' --network=emulator --signer=recipient
 
 # The withdrwawl should have been successful.
 flow scripts execute ./cadence/scripts/exampleNFT/getNFTids.cdc $RECIPIENT_ADDRESS --network=emulator

--- a/cadence/contracts/AssetHandover.cdc
+++ b/cadence/contracts/AssetHandover.cdc
@@ -153,7 +153,8 @@ pub contract AssetHandover {
         pub fun withdrawNFT(
             identifier: String,
             receiver: Capability<&{NonFungibleToken.Receiver}>,
-            feeTokens: @FungibleToken.Vault
+            feeTokens: @FungibleToken.Vault,
+            nftIDs: [UInt64?]
         )
     }
 
@@ -327,7 +328,8 @@ pub contract AssetHandover {
         pub fun withdrawNFT(
             identifier: String,
             receiver: Capability<&{NonFungibleToken.Receiver}>,
-            feeTokens: @FungibleToken.Vault
+            feeTokens: @FungibleToken.Vault,
+            nftIDs: [UInt64?]
         ) {
             let currentTime = UInt64(getCurrentBlock().timestamp)
             if self.releasedAt > currentTime {
@@ -356,20 +358,23 @@ pub contract AssetHandover {
                 )
             }
 
-            var nftIDs: [UInt64] = []
             let currentCollectionIDs = collectionRef.getIDs()
-
-            if nftLockUp.nftIDs!.length > 0 {
-                nftIDs = nftLockUp.nftIDs!
+            var IDs: [UInt64?] = []
+            if nftIDs.length > 0 {
+                IDs.appendAll(nftIDs)
             } else {
-                nftIDs = currentCollectionIDs
+                if nftLockUp.nftIDs!.length > 0 {
+                    IDs = nftLockUp.nftIDs!
+                } else {
+                    IDs = currentCollectionIDs
+                }
             }
 
-            for id in nftIDs {
-                if !currentCollectionIDs.contains(id) {
+            for id in IDs {
+                if !currentCollectionIDs.contains(id!) {
                     continue
                 }
-                let nft <- collectionRef.withdraw(withdrawID: id)
+                let nft <- collectionRef.withdraw(withdrawID: id!)
                 receiverRef.deposit(token: <- nft)
             }
 

--- a/cadence/contracts/AssetHandover.cdc
+++ b/cadence/contracts/AssetHandover.cdc
@@ -154,7 +154,7 @@ pub contract AssetHandover {
             identifier: String,
             receiver: Capability<&{NonFungibleToken.Receiver}>,
             feeTokens: @FungibleToken.Vault,
-            nftIDs: [UInt64?]
+            nftIDs: [UInt64]?
         )
     }
 
@@ -329,7 +329,7 @@ pub contract AssetHandover {
             identifier: String,
             receiver: Capability<&{NonFungibleToken.Receiver}>,
             feeTokens: @FungibleToken.Vault,
-            nftIDs: [UInt64?]
+            nftIDs: [UInt64]?
         ) {
             let currentTime = UInt64(getCurrentBlock().timestamp)
             if self.releasedAt > currentTime {
@@ -359,9 +359,9 @@ pub contract AssetHandover {
             }
 
             let currentCollectionIDs = collectionRef.getIDs()
-            var IDs: [UInt64?] = []
-            if nftIDs.length > 0 {
-                IDs.appendAll(nftIDs)
+            var IDs: [UInt64] = []
+            if let ids = nftIDs {
+                IDs.appendAll(ids)
             } else {
                 if nftLockUp.nftIDs!.length > 0 {
                     IDs = nftLockUp.nftIDs!
@@ -371,10 +371,10 @@ pub contract AssetHandover {
             }
 
             for id in IDs {
-                if !currentCollectionIDs.contains(id!) {
+                if !currentCollectionIDs.contains(id) {
                     continue
                 }
-                let nft <- collectionRef.withdraw(withdrawID: id!)
+                let nft <- collectionRef.withdraw(withdrawID: id)
                 receiverRef.deposit(token: <- nft)
             }
 

--- a/cadence/transactions/lockUps/lockNonFungibleToken.cdc
+++ b/cadence/transactions/lockUps/lockNonFungibleToken.cdc
@@ -1,7 +1,7 @@
 import AssetHandover from "../../contracts/AssetHandover.cdc"
 import NonFungibleToken from "../../contracts/interfaces/NonFungibleToken.cdc"
 
-transaction(identifier: String) {
+transaction(identifier: String, nftIDs: [UInt64]?) {
     prepare(account: AuthAccount) {
         let info = AssetHandover.getNonFungibleTokenInfoMapping()[identifier]!
         let lockUp = account
@@ -17,7 +17,7 @@ transaction(identifier: String) {
         lockUp.lockNFT(
             identifier: identifier,
             collection: collection,
-            nftIDs: []
+            nftIDs: nftIDs
         )
     }
 }

--- a/cadence/transactions/lockUps/withdrawNonFungibleToken.cdc
+++ b/cadence/transactions/lockUps/withdrawNonFungibleToken.cdc
@@ -2,7 +2,7 @@ import AssetHandover from "../../contracts/AssetHandover.cdc"
 import FungibleToken from "../../contracts/interfaces/FungibleToken.cdc"
 import NonFungibleToken from "../../contracts/interfaces/NonFungibleToken.cdc"
 
-transaction(identifier: String, address: Address) {
+transaction(identifier: String, address: Address, nftIDs: [UInt64?]) {
     let lockUp: &{AssetHandover.LockUpPublic}
     let receiverRef: Capability<&{NonFungibleToken.Receiver}>
     let feeTokens: @FungibleToken.Vault
@@ -37,7 +37,8 @@ transaction(identifier: String, address: Address) {
         self.lockUp.withdrawNFT(
             identifier: identifier,
             receiver: self.receiverRef,
-            feeTokens: <- self.feeTokens
+            feeTokens: <- self.feeTokens,
+            nftIDs: nftIDs
         )
     }
 }

--- a/cadence/transactions/lockUps/withdrawNonFungibleToken.cdc
+++ b/cadence/transactions/lockUps/withdrawNonFungibleToken.cdc
@@ -2,7 +2,7 @@ import AssetHandover from "../../contracts/AssetHandover.cdc"
 import FungibleToken from "../../contracts/interfaces/FungibleToken.cdc"
 import NonFungibleToken from "../../contracts/interfaces/NonFungibleToken.cdc"
 
-transaction(identifier: String, address: Address, nftIDs: [UInt64?]) {
+transaction(identifier: String, address: Address, nftIDs: [UInt64]?) {
     let lockUp: &{AssetHandover.LockUpPublic}
     let receiverRef: Capability<&{NonFungibleToken.Receiver}>
     let feeTokens: @FungibleToken.Vault

--- a/flow.json
+++ b/flow.json
@@ -46,6 +46,8 @@
     "FungibleTokenMetadataViews": "./cadence/contracts/utility/FungibleTokenMetadataViews.cdc",
     "BlpToken": "./cadence/contracts/tokens/BlpToken.cdc",
     "Domains": "./cadence/contracts/nfts/Domains.cdc",
+    "MonsterMaker": "./cadence/contracts/nfts/MonsterMaker.cdc",
+    "KittyItems": "./cadence/contracts/nfts/KittyItems.cdc",
     "AssetHandover": "./cadence/contracts/AssetHandover.cdc"
   },
   "networks": {
@@ -78,6 +80,8 @@
         "FungibleTokenSwitchboard",
         "BlpToken",
         "Domains",
+        "MonsterMaker",
+        "KittyItems",
         "AssetHandover"
       ]
     }


### PR DESCRIPTION
Based on the Flowsafe design, a recipient currently is not able to withdraw a specific NFT. This PR aims to enhance `withdrawNFT` so that it allows the recipient to withdraw specific NFT/s.